### PR TITLE
sysdeps/ia64: Drop unneeded cmp.ne.and from strcmp

### DIFF
--- a/sysdeps/ia64/strcmp.S
+++ b/sysdeps/ia64/strcmp.S
@@ -43,7 +43,6 @@ ENTRY(strcmp)
 	cmp.eq	p6, p0 = r0, r0		// set p6
 	;;
 	cmp.ne.and p6, p0 = val1, r0
-	cmp.ne.and p6, p0 = val2, r0
 	cmp.eq.and p6, p0 = val1, val2
 (p6)	br.cond.sptk .loop
 	sub	ret0 = val1, val2


### PR DESCRIPTION
It is only needed to compare one of val1, val2 against zero, because whenever val1 != 0 && val2 == 0, then also val1 != val2.

Drop the second comparison, and reduce the loop to two bundles, leading to improved performance.
