### PR TITLE
sysdeps/ia64: Fix alloc/br.ret WAW hazard in strncmp

### DIFF
--- a/sysdeps/ia64/strncmp.S
+++ b/sysdeps/ia64/strncmp.S
@@ -48,6 +48,7 @@
 
 ENTRY(strncmp)
 	alloc	r2 = ar.pfs, 3, 0, 0, 0
+	;;
 	adds	tmp = 1, sx1		// pre-compute sx1 + 1 for both sentinel (sx1 + n + 1) and sy1 (sx1 + 1)
 	mov	one = 1
 	mov	ret0 = r0


### PR DESCRIPTION
The assembly language implementation of strncmp() is missing a stop between alloc and a subsequent br.ret in an early bail-out path.

On some system, this causes SIGILL. Add the stop to fix the issue.

---

Patch by René Rebe, original source: https://svn.exactcode.de/t2/trunk/package/base/glibc/0000.patch.ia64. Tested with strncmp unit tests.